### PR TITLE
Make examples work on linux

### DIFF
--- a/examples/config.nims
+++ b/examples/config.nims
@@ -4,3 +4,5 @@ switch("path", "../src")
 when defined(windows):
   switch("passL", r"-Lc:\VulkanSDK\1.0.61.1\Lib")
   switch("passL", "-lvulkan-1")
+elif defined(linux):
+  switch("passL", r"/usr/lib/libvulkan.so.1")


### PR DESCRIPTION
This binding works(from my experience) perfectly in linux and to make the examples work requires only 2 additional lines in `config.nims`